### PR TITLE
Defeat screen refactor

### DIFF
--- a/client/src/components/gamedashboard/bottom/trading/TradeRequest.vue
+++ b/client/src/components/gamedashboard/bottom/trading/TradeRequest.vue
@@ -39,7 +39,6 @@
         mode="outgoing"
         class="options-block tour-give-up"
         v-show="tradePartnerName || isInTutorial"
-        :key="count"
         :resources="sentResources"
       />
       <TradeOptions
@@ -48,7 +47,6 @@
         mode="incoming"
         class="options-block tour-get-in-return"
         v-show="tradePartnerName || isInTutorial"
-        :key="count + 'get'"
         :resources="exchangeResources"
       />
     </div>
@@ -103,12 +101,6 @@ export default class TradeRequest extends Vue {
 
   get exchangeResources(){
     return this.$tstore.state.ui.tradeData.from.resourceAmount;
-  }
-
-
-  get uiDefaultTradeData(){
-    console.log(this.$tstore.state.ui.tradeData);
-    return this.$tstore.state.ui.tradeData;
   }
 
   get otherPlayers() {
@@ -190,10 +182,10 @@ export default class TradeRequest extends Vue {
 
       if (!this.isInTutorial){
         this.$tstore.commit('SET_TRADE_PARTNER_NAME','' as Role);
-        this.$tstore.commit('SET_GET_RESOURCES', defaultInventory());
+        this.$tstore.commit('SET_SEND_RESOURCES', defaultInventory());
         this.$tstore.commit('SET_GET_RESOURCES', defaultInventory());
       }
-      this.count+=1;
+      
     }
   }
 }

--- a/client/src/components/gamedashboard/global/cards/CardInvestment.vue
+++ b/client/src/components/gamedashboard/global/cards/CardInvestment.vue
@@ -2,7 +2,7 @@
   <div class="card-investment v-step-15">
     <div class="ci-container" :style="opacity">
       <div class="type">
-        <p class="name">{{ name }}</p>
+        <p class="name">{{ returnName }}</p>
         <img :src="require(`@/assets/icons/${name}.svg`)" alt="Player" />
         <div class="data">
           <div
@@ -77,6 +77,11 @@ export default class CardInvestment extends Vue {
     ];
     if (pendingUnits) return pendingUnits;
     return 0;
+  }
+
+
+  get returnName(){
+    return this.name == 'upkeep' ? 'System Health' : this.name;
   }
 
   private setInvestmentAmount(diff: number): void {

--- a/client/src/components/gamedashboard/global/cards/CardInvestment.vue
+++ b/client/src/components/gamedashboard/global/cards/CardInvestment.vue
@@ -2,7 +2,7 @@
   <div class="card-investment v-step-15">
     <div class="ci-container" :style="opacity">
       <div class="type">
-        <p class="name">{{ lable }}</p>
+        <p class="name">{{ label }}</p>
         <img :src="require(`@/assets/icons/${name}.svg`)" alt="Player" />
         <div class="data">
           <div
@@ -80,7 +80,7 @@ export default class CardInvestment extends Vue {
   }
 
 
-  get lable(){
+  get label() {
     return this.name == ('upkeep' as any) ? 'System Health' : this.name;
   }
 

--- a/client/src/components/gamedashboard/global/cards/CardInvestment.vue
+++ b/client/src/components/gamedashboard/global/cards/CardInvestment.vue
@@ -81,7 +81,7 @@ export default class CardInvestment extends Vue {
 
 
   get returnName(){
-    return this.name == 'upkeep' ? 'System Health' : this.name;
+    return this.name == ('upkeep' as any) ? 'System Health' : this.name;
   }
 
   private setInvestmentAmount(diff: number): void {

--- a/client/src/components/gamedashboard/global/cards/CardInvestment.vue
+++ b/client/src/components/gamedashboard/global/cards/CardInvestment.vue
@@ -2,7 +2,7 @@
   <div class="card-investment v-step-15">
     <div class="ci-container" :style="opacity">
       <div class="type">
-        <p class="name">{{ returnName }}</p>
+        <p class="name">{{ lable }}</p>
         <img :src="require(`@/assets/icons/${name}.svg`)" alt="Player" />
         <div class="data">
           <div
@@ -80,7 +80,7 @@ export default class CardInvestment extends Vue {
   }
 
 
-  get returnName(){
+  get lable(){
     return this.name == ('upkeep' as any) ? 'System Health' : this.name;
   }
 

--- a/client/src/components/gamedashboard/global/containers/ContainerDefeat.vue
+++ b/client/src/components/gamedashboard/global/containers/ContainerDefeat.vue
@@ -11,7 +11,7 @@
           <p class="time"><span>[ </span>{{ marsLogTime(log.timestamp) }}<span> ]</span></p>
         </div>
       </div>
-      <h4 class="death-text">Final Game State:<span class="death"><i>Death</i></span></h4>
+      <h4 class="death-text">Final Game State:<span class="death"><i>System Health reached zero</i></span></h4>
     </div>
 
     <div class="thanks">

--- a/client/src/components/gamedashboard/global/containers/ContainerDefeat.vue
+++ b/client/src/components/gamedashboard/global/containers/ContainerDefeat.vue
@@ -1,23 +1,34 @@
 <template>
   <div class="container-defeat">
-    <h1 class="animated pulse slower infinite">Game Over</h1>
-    <div class="text">
-      <p>
-        System Health has reached zero. However, your efforts will inspire a new
-        generation to continue your legacy on Mars.
-      </p>
-      <p>Thank you for playing.</p>
+    <h1 class="animated pulse slower infinite gameOver-text">Game Over</h1>
+    <div class="transmission-info">
+      <h3>Replaying Logs before death...</h3>
+      
+      <div class="message-container">
+        <div v-for="log in marsLogEvents" :style="marsLogColor(log)"  class="message" :key="log.timestamp">
+          <p class="category">{{ log.category }}</p>
+          <p class="content">{{ log.content }}</p>
+          <p class="time"><span>[ </span>{{ marsLogTime(log.timestamp) }}<span> ]</span></p>
+        </div>
+      </div>
+      <h4 class="death-text">Final Game State:<span class="death"><i>Death</i></span></h4>
     </div>
-    <div class="buttons">
-      <button @click="handleRestart">Restart the Game</button>
-      <button @click="handleExit">Exit</button>
+
+    <div class="thanks">
+      <p>Thank you for playing</p>
+      <div class="buttons">
+        <button @click="handleRestart">Restart the Game</button>
+        <button @click="handleExit">Exit</button>
+      </div>
     </div>
   </div>
+
 </template>
 
 <script lang="ts">
 import {Vue, Component, InjectReactive, Inject} from 'vue-property-decorator';
 import { GameRequestAPI } from '@/api/game/request';
+import {MarsLogData} from 'shared/types';
 
 @Component({})
 export default class ContainerDefeat extends Vue {
@@ -27,8 +38,31 @@ export default class ContainerDefeat extends Vue {
     this.api.resetGame();
   }
 
+  get marsLogEvents(){
+    console.log(this.$store.getters.marsLogEvents);
+    return this.$store.getters.logs; 
+  }
+
+  marsLogTime(timestamp: number) {
+    return new Date(timestamp).toLocaleTimeString();
+  }
+
   private handleExit() {
     console.log('EXIT GAME');
+  }
+
+  marsLogColor(log: MarsLogData) {
+    console.log(log.category)
+    switch (log.category) {
+      case 'System Health: Drop':
+        return { backgroundColor: 'var(--marslog-red)' };
+      case 'System Health: Gain':
+        return { backgroundColor: 'var(--marslog-green)' };
+      case 'Trade':
+        return { backgroundColor: 'var(--marslog-purple)' };
+      default:
+        return { backgroundColor: 'var(--space-white-opaque-1)' };
+    }
   }
 }
 </script>

--- a/client/src/components/gamedashboard/top/MarsLog.vue
+++ b/client/src/components/gamedashboard/top/MarsLog.vue
@@ -36,7 +36,9 @@ export default class MarsLog extends Vue {
   marsLogColor(log: MarsLogData) {
     console.log(log.category)
     switch (log.category) {
-      case 'upkeep':
+      case 'System Health: Gain':
+        return { backgroundColor: 'var(--marslog-green)' };
+      case 'System Health: Drop':
         return { backgroundColor: 'var(--marslog-red)' };
       case 'Trade':
         return { backgroundColor: 'var(--marslog-purple)' };

--- a/client/src/stylesheets/gamedashboard/bottom/containers/ContainerTrade.scss
+++ b/client/src/stylesheets/gamedashboard/bottom/containers/ContainerTrade.scss
@@ -43,7 +43,7 @@
 
     .trades-wrapper {
       margin: 0 0.5rem;
-      background-color: blue;
+      
     }
   }
 }

--- a/client/src/stylesheets/gamedashboard/bottom/trading/Trade.scss
+++ b/client/src/stylesheets/gamedashboard/bottom/trading/Trade.scss
@@ -172,7 +172,8 @@
       transition: all 0.2s ease-in-out;
 
       &:hover {
-        transform: scale(1.1);
+        transform: scaleX(1.1);
+        overflow:hidden;
       }
     }
 

--- a/client/src/stylesheets/gamedashboard/global/containers/ContainerDefeat.scss
+++ b/client/src/stylesheets/gamedashboard/global/containers/ContainerDefeat.scss
@@ -1,47 +1,76 @@
-.container-defeat {
-  @include expand;
-  /* SET MAX SIZE OF SCREEN */
-  max-height: $max-screen-height;
-  max-width: $max-screen-width;
-  /* SET MIN SIZE OF SCREEN */
-  min-height: $min-screen-height;
-  min-width: $min-screen-width;
-  padding: 1rem;
-  @include make-column-and-center;
-  justify-content: space-around;
-  background-color: $space-gray;
+.container-defeat{
+    color:white;
+    
+    width: 50rem;
+    margin-left: auto;
+    margin-right: auto;
+    background-color: $space-gray;
 
-  h1 {
-    color: $new-space-orange;
-  }
-
-  .text {
-    @include make-column-and-center;
-
-    p {
-      margin: 0.5rem;
-      font-size: $font-large;
-      text-align: center;
-      color: $space-white;
+    .gameOver-text{
+        color: $new-space-orange;
     }
-  }
 
-  .buttons {
-    @include make-center;
 
-    button {
-      @include reset-button;
-      height: 3rem;
-      width: 12.5rem;
-      border: 0.0625rem solid $new-space-orange;
-      margin: 0.5rem;
-      color: $new-space-orange;
-      @include default-transition-base;
+    .message-container{
+        display: flex;
+        flex-direction: column;
+        height: 20rem;
+        overflow-y: scroll;
+        //@include disable-scroll;
 
-      &:hover {
-        color: $space-gray;
-        background-color: $new-space-orange;
-      }
+        .message{
+            margin-bottom: 1rem;
+            padding:0.4rem;
+            
+        }
+
+        &:last-child {
+            margin-bottom: 0;
+        }
     }
-  }
+
+
+    
+
+    @keyframes example {
+        from {opacity: 0;}
+        to {opacity: 100;}
+    }
+
+    
+
+    .death-text{
+        margin-top:1rem;
+        
+
+        .death{
+            color: $status-red;
+            margin-left: 0.1rem;
+        }
+    }
+
+
+    .thanks{
+        margin-top: 2rem;
+        text-align: center;
+
+        .buttons {
+            @include make-center;
+        
+            button {
+                @include reset-button;
+                height: 3rem;
+                width: 12.5rem;
+                border: 0.0625rem solid $new-space-orange;
+                margin: 0.5rem;
+                color: $new-space-orange;
+                @include default-transition-base;
+        
+                &:hover {
+                color: $space-gray;
+                background-color: $new-space-orange;
+                }
+            }
+        }
+    }
 }

--- a/client/src/stylesheets/utilities/_variables.scss
+++ b/client/src/stylesheets/utilities/_variables.scss
@@ -35,6 +35,7 @@ $status-yellow: rgba(199, 168, 40, 1);
 $status-red: rgba(170, 42, 41, 1);
 
 $marslog-red: rgba(170, 42, 41, 0.05);
+$marslog-green: rgba(9, 92, 41, 0.5);
 $marslog-purple: rgba(111, 36, 134, 0.05);
 
 // BORDERS

--- a/client/src/views/Tutorial.vue
+++ b/client/src/views/Tutorial.vue
@@ -293,11 +293,15 @@ export default class Tutorial extends Vue {
       this.currentQuizQuestion.id,
       value
     );
-    if (result) {
-      this.quizQuestionStatusMessage = 'Correct! Please click next.';
-      this.quizQuestionStatus = true;
-    } else {
-      this.quizQuestionStatusMessage = 'Incorrect, please try again.';
+    if(!this.quizQuestionStatus){
+      if (result) {
+        this.quizQuestionStatusMessage = 'Correct! Please click next.';
+        this.quizQuestionStatus = true;
+      } else {
+        this.quizQuestionStatusMessage = 'Incorrect, please try again.';
+      }
+    } else{
+      this.quizQuestionStatusMessage = 'You already answered correctly. Please click next.';
     }
   }
 

--- a/server/src/rooms/game/events/index.ts
+++ b/server/src/rooms/game/events/index.ts
@@ -259,15 +259,8 @@ export class EnteredMarsEventPhase extends KindOnlyGameEvent {
     const oldUpkeep = game.upkeep;
     game.upkeep = game.nextRoundUpkeep();
 
-    const log = new MarsLogMessage({
-      performedBy: 'Server',
-      category: `System Health: ${oldUpkeep-game.upkeep > 0 ? 'Drop' : 'Gain'}`,
-      content: `Upkeep is now at ${game.upkeep}%, a ${Math.abs(oldUpkeep-game.upkeep)}% ${oldUpkeep-game.upkeep > 0 ? 'drop' : 'gain'} 
-      from last round`,
-      timestamp: this.dateCreated
-    });
-
-    game.logs.push(log);
+    game.log(`System Health is now at ${game.upkeep}%, a ${Math.abs(oldUpkeep-game.upkeep)}% ${oldUpkeep-game.upkeep > 0 ? 'drop' : 'gain'} 
+    from last round`, `System Health: ${oldUpkeep-game.upkeep > 0 ? 'Drop' : 'Gain'}`, `Server`);
 
     game.resetPlayerReadiness();
     game.resetPlayerContributedUpkeep();
@@ -359,14 +352,8 @@ export class EnteredDefeatPhase extends KindOnlyGameEvent {
   apply(game: GameState): void {
     if(game.upkeep <= 0){
       game.phase = Phase.defeat;
-      const log = new MarsLogMessage({
-        performedBy: 'Server',
-        category: 'System Health',
-        content: `System health has reached zero.`,
-        timestamp: this.dateCreated
-      });
-
-      game.logs.push(log);
+      
+      game.log(`System Health has reached zero.`, 'System Health', 'Server');
     }
 
   }


### PR DESCRIPTION
--Updates--
*Changed upkeep to system health in mars log message as per @chrstngyn 

*Added 'System Health has reached zero' as per @alee 

*Using game.log(..) as per @alee 

*changed returnName to label as per @alee 


---Defeat Screen---
*Has logs of what happened during the game

*New Defeat logic, which should fix Sandstorm error

---Tutorial Changes---
*Upkeep renamed to system health in investment card

*Trade Request amount variables are set to 0 when reset

*Trades no longer have a blue bar between them

*Trade buttons expand in the x direction, but not y.

*Tutorial Quiz incorrect/correct style handling