### PR TITLE
fix: trigger changes for all structures upon re/joining room

### DIFF
--- a/client/src/api/game/response.ts
+++ b/client/src/api/game/response.ts
@@ -87,6 +87,8 @@ export function applyGameServerResponses<T>(room: Room, store: TStore) {
     store.commit('REMOVE_FROM_CHAT', deschemify(msg));
   };
 
+  room.state.messages.triggerAll();
+
   room.state.logs.onAdd = (
     logMsg: Schemify<MarsLogMessageData>,
     index: number
@@ -100,6 +102,8 @@ export function applyGameServerResponses<T>(room: Room, store: TStore) {
   ) => {
     store.commit('REMOVE_FROM_MARS_LOG', deschemify(logMsg));
   };
+
+  room.state.logs.triggerAll();
 
   // RESPONSES FOR EVENTS :: START
 
@@ -127,6 +131,8 @@ export function applyGameServerResponses<T>(room: Room, store: TStore) {
     store.commit('CHANGE_EVENT', { event: deschemify(event), index });
   };
 
+  room.state.marsEvents.triggerAll();
+
   room.state.tradeSet.onAdd = (event: Schemify<TradeData>, id: string) => {
     const rawEvent: TradeData = deschemify(event);
     store.commit('ADD_TO_TRADES', { trade: rawEvent, id });
@@ -135,6 +141,8 @@ export function applyGameServerResponses<T>(room: Room, store: TStore) {
   room.state.tradeSet.onRemove = (event: Schemify<TradeData>, id: string) => {
     store.commit('REMOVE_FROM_TRADES', { id });
   };
+
+  room.state.tradeSet.triggerAll();
 
   room.state.onChange = (changes: Array<any>) => {
     changes.forEach(change => {
@@ -163,4 +171,6 @@ export function applyGameServerResponses<T>(room: Room, store: TStore) {
       }
     });
   };
+
+  room.state.triggerAll();
 }


### PR DESCRIPTION
Fixes https://github.com/virtualcommons/port-of-mars/issues/377

By calling `.triggerAll()`, the callbacks previously registered on the Schema structures are going to be triggered forcibly.

Can you review this in the actual game @alee? It may (or may not) have unexpected visual results. Let me know if it works!

(`.triggerAll()` is a workaround that is planned to be improved on `@colyseus/schema` in the future 🙈 )