### PR TITLE
feat: defeat screen mars log additional styling

### DIFF
--- a/client/src/components/game/accomplishments/AccomplishmentCard.vue
+++ b/client/src/components/game/accomplishments/AccomplishmentCard.vue
@@ -120,10 +120,16 @@ export default class AccomplishmentCard extends Vue {
   }
 
   private handleClick() {
-    this.$root.$emit('openModalCard', {
-      card: 'accomplishment',
-      payload: this.accomplishment,
-    });
+    this.$tstore.commit('SET_CARD_MODAL_VISIBILITY', {
+      visible: true,
+      data:{
+        type:'ModalCard',
+        info:{
+          card: 'accomplishment',
+          payload: this.accomplishment
+        },
+      }
+    })
   }
 
   get cardTypeStyling() {
@@ -183,18 +189,26 @@ export default class AccomplishmentCard extends Vue {
   private handleDiscard() {
     if (this.$store.getters.layout == 'tutorial') {
       this.api.discardAccomplishment(this.accomplishment.id);
+
     } else {
-      this.$root.$emit('openmodalconfirmation', {
-        text: `Selecting \"Yes\" will discard the accomplishment \"${this.accomplishment.label}\" and a new card will be drawn next round.`,
-        victoryPoints: this.accomplishment.victoryPoints,
-        cost: this.accomplishmentCost,
-        phaseOpened: this.$store.state.phase,
-        type: 'discardAccomplishment',
-        actionData: this.accomplishment.id,
-      });
+      this.$tstore.commit('SET_CARD_MODAL_VISIBILITY', {
+      visible: true,
+      data:{
+        type:'ModalConfirmation',
+        info:{
+          text: `Selecting \"Yes\" will discard the accomplishment \"${this.accomplishment.label}\" and a new card will be drawn next round.`,
+          victoryPoints: this.accomplishment.victoryPoints,
+          cost: this.accomplishmentCost,
+          phaseOpened: this.$store.state.phase,
+          type: 'discardAccomplishment',
+          actionData: this.accomplishment.id
+        },
+      }
+    })
+
+    }
     }
   }
-}
 </script>
 
 <style lang="scss" scoped>

--- a/client/src/components/game/modals/ModalConfirmation.vue
+++ b/client/src/components/game/modals/ModalConfirmation.vue
@@ -52,6 +52,16 @@ export default class ModalConfirmation extends Vue {
     switch (this.modalData.type) {
       case 'discardAccomplishment':
         this.api.discardAccomplishment(this.modalData.actionData);
+        this.$tstore.commit('SET_CARD_MODAL_VISIBILITY', {
+        visible: false,
+        data:{
+          type:'',
+          info:{
+              card:'',
+              payload:null
+            },
+        }
+      })
       default:
         break;
     }

--- a/client/src/components/game/modals/ModalController.vue
+++ b/client/src/components/game/modals/ModalController.vue
@@ -45,6 +45,7 @@ export default class ModalController extends Vue{
     }
 
     get cardModal(){
+        console.log(this.$tstore.state.ui.modalViews.cardModal);
         return this.$tstore.state.ui.modalViews.cardModal;
     }
 }

--- a/client/src/components/game/static/NewMarsLog.vue
+++ b/client/src/components/game/static/NewMarsLog.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="c-marslog">
+    <div class="wrapper">
+      <p v-if="logs.length === 0" class="empty">
+        No Logs
+      </p>
+      <div
+        v-for="log in logs"
+        :style="marsLogColor(log)"
+        :key="log.timestamp + Math.random()"
+        class="message"
+      >
+        <p class="category">{{ log.category }}</p>
+        <p class="content">{{ log.content }}</p>
+        <p class="time">
+          <span>[ </span>{{ marsLogTime(log.timestamp) }}<span> ]</span>
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { MarsLogData } from '@port-of-mars/shared/types';
+
+@Component({
+  components: {}
+})
+export default class NewMarsLog extends Vue {
+  updated() {
+    const elem = this.$el.querySelector('.wrapper');
+    elem!.scrollTop = elem!.scrollHeight;
+  }
+
+  get logs() {
+    return this.$tstore.getters.logs;
+  }
+
+  marsLogTime(timestamp: number) {
+    return new Date(timestamp).toLocaleTimeString();
+  }
+
+  marsLogColor(log: MarsLogData) {
+    switch (log.category) {
+      case 'System Health: Gain':
+        return { backgroundColor: 'var(--marslog-green)' };
+      case 'System Health: Drop':
+        return { backgroundColor: 'var(--marslog-red)' };
+      case 'Trade':
+        return { backgroundColor: 'var(--marslog-purple)' };
+      default:
+        return { backgroundColor: 'var(--space-white-opaque-1)' };
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '@port-of-mars/client/stylesheets/game/static/NewMarsLog.scss';
+</style>

--- a/client/src/components/root/ContainerDefeat.vue
+++ b/client/src/components/root/ContainerDefeat.vue
@@ -5,13 +5,17 @@
       <h3>Replaying Logs before death...</h3>
 
       <div class="message-container">
-        <div
-          v-for="log in marsLogEvents"
-          :style="marsLogColor(log)"
-          class="message"
-          :key="log.timestamp + Math.random()"
-        >
-          <p class="category">{{ log.category }}</p>
+        <div v-for="(log,index) in marsLogEvents" :style="marsLogColor(log)" 
+        class="message"
+        v-bind="{class:`animated fadeInLeft delay-${0.6*index}s`}"
+        :key="log.timestamp">
+          <div class="header">
+            <p class="category">{{ log.category }}</p>
+            <div class="event-number">
+              <p class="final-log" v-if="index==0">Final Log</p>
+              <p v-else>Log Entry <span class="list">#{{marsLogEvents.length-index}}/{{marsLogEvents.length}}</span></p>
+            </div>
+          </div>
           <p class="content">{{ log.content }}</p>
           <p class="time">
             <span>[ </span>{{ marsLogTime(log.timestamp) }}<span> ]</span>
@@ -40,7 +44,7 @@
 <script lang="ts">
 import { Vue, Component, InjectReactive, Inject } from 'vue-property-decorator';
 import { GameRequestAPI } from '@port-of-mars/client/api/game/request';
-import { MarsLogData } from '@port-of-mars/shared/types';
+import {MarsLogData, ROLES} from '@port-of-mars/shared/types';
 
 @Component({})
 export default class ContainerDefeat extends Vue {
@@ -50,8 +54,9 @@ export default class ContainerDefeat extends Vue {
   //   this.api.resetGame();
   // }
 
-  get marsLogEvents() {
-    return this.$store.getters.logs;
+  get marsLogEvents(){
+    console.log(this.$store.getters.marsLogEvents);
+    return this.$store.getters.logs.reverse();
   }
 
   marsLogTime(timestamp: number) {
@@ -63,21 +68,19 @@ export default class ContainerDefeat extends Vue {
   }
 
   marsLogColor(log: MarsLogData) {
-    switch (log.category) {
-      case 'System Health: Drop':
-        return { backgroundColor: 'var(--marslog-red)' };
-      case 'System Health: Gain':
-        return { backgroundColor: 'var(--marslog-green)' };
-      case 'Trade':
-        return { backgroundColor: 'var(--marslog-purple)' };
-      default:
-        return { backgroundColor: 'var(--space-white-opaque-1)' };
-    }
+    console.log(log.category)
+    if(log.category == 'SYSTEM HEALTH- DROP') return { backgroundColor: 'var(--marslog-red)'};
+    else if(log.category == 'SYSTEM HEALTH- GAIN') return { backgroundColor: 'var(--marslog-green)'};
+    else if(log.category == 'TRADE') return { backgroundColor: 'var(--marslog-purple)'};
+    else if(log.category.includes('Mars Event')) return { backgroundColor: 'var(--marslog-orange)'};
+    else return { backgroundColor: 'var(--space-white-opaque-1)' }
   }
+
 }
 </script>
 
 <style lang="scss" scoped>
 @import '~animate.css/source/attention_seekers/pulse.css';
+@import '~animate.css/source/fading_entrances/fadeInLeft.css';
 @import '@port-of-mars/client/stylesheets/root/ContainerDefeat.scss';
 </style>

--- a/client/src/stylesheets/game/static/NewMarsLog.scss
+++ b/client/src/stylesheets/game/static/NewMarsLog.scss
@@ -1,0 +1,57 @@
+.c-marslog {
+  @include expand;
+  @include make-column-and-center;
+  // background-color: cadetblue;
+
+  .wrapper {
+    @include expand;
+    overflow-y: scroll;
+    @include disable-scroll;
+
+    .empty {
+      margin-bottom: 0;
+      font-size: $font-med;
+      text-align: center;
+      color: $space-white-opaque-2;
+    }
+
+    .message {
+      height: auto;
+      max-width: 100%;
+      padding: 0.5rem;
+      margin-bottom: 0.5rem;
+      font-size: $font-med;
+      color: $space-white;
+      overflow: auto;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+
+      .category {
+        margin: 0;
+        text-transform: capitalize;
+        color: $new-space-orange;
+        font-weight: $font-weight-maven-pro-bold;
+      }
+
+      .content,
+      .time {
+        font-weight: $font-weight-maven-pro-regular;
+      }
+
+      .content {
+        margin: 0.5rem 0;
+        word-wrap: break-word;
+      }
+
+      .time {
+        margin: 0;
+
+        span {
+          color: $new-space-orange;
+        }
+      }
+    }
+  }
+}

--- a/client/src/stylesheets/main.scss
+++ b/client/src/stylesheets/main.scss
@@ -42,6 +42,9 @@ body {
   --status-green: rgba(45, 143, 68, 1);
   --marslog-red: rgba(170, 42, 41, 0.05);
   --marslog-purple: rgba(111, 36, 134, 0.05);
+  --marslog-orange: rgba(170, 111, 0, 0.05);
+  --marslog-green: rgba(9, 92, 41, 0.5);
+
 }
 
 p,

--- a/client/src/stylesheets/root/ContainerDefeat.scss
+++ b/client/src/stylesheets/root/ContainerDefeat.scss
@@ -16,12 +16,28 @@
         flex-direction: column;
         height: 20rem;
         overflow-y: scroll;
-        //@include disable-scroll;
 
         .message{
             margin-bottom: 1rem;
             padding:0.4rem;
             
+            .header{
+                display: flex;
+                justify-content: space-between;
+                
+                .event-number{
+                    color: $new-space-orange;
+                    .final-log{
+                        color: white;
+                        font-style: italic;
+                        font-weight: bold;
+                    }
+
+                    .list{
+                        color: white;
+                    }
+                }
+            }
         }
 
         &:last-child {

--- a/client/src/stylesheets/utilities/_variables.scss
+++ b/client/src/stylesheets/utilities/_variables.scss
@@ -42,6 +42,7 @@ $status-red: rgba(170, 42, 41, 1);
 $marslog-red: rgba(170, 42, 41, 0.05);
 $marslog-green: rgba(9, 92, 41, 0.5);
 $marslog-purple: rgba(111, 36, 134, 0.05);
+$marslog-orange: rgba(170, 111, 0, 0.05);
 
 // BORDERS
 $border-white: 0.125rem solid $space-white;

--- a/server/src/data/MarsEvents.ts
+++ b/server/src/data/MarsEvents.ts
@@ -229,16 +229,16 @@ const _marsEvents: Array<[MarsEventData, number]> = [
 
 const marsEvents: Array<[MarsEventData, number]> = [
   [_.find(_marsEvents, e => e[0].id === 'personalGain')![0], 1],
-  // [_.find(_marsEvents, e => e[0].id === 'sandstorm')![0], 1],
-  // [_.find(_marsEvents, e => e[0].id === 'compulsivePhilanthropy')![0], 1],
-  // [_.find(_marsEvents, e => e[0].id === 'outOfCommissionCurator')![0], 1],
-  // [_.find(_marsEvents, e => e[0].id === 'outOfCommissionPolitician')![0], 1],
-  // [_.find(_marsEvents, e => e[0].id === 'outOfCommissionResearcher')![0], 1],
-  // [_.find(_marsEvents, e => e[0].id === 'outOfCommissionPioneer')![0], 1],
-  // [_.find(_marsEvents, e => e[0].id === 'outOfCommissionEntrepreneur')![0], 1],
-  // [_.find(_marsEvents, e => e[0].id === 'audit')![0], 1],
-  // [_.find(_marsEvents, e => e[0].id === 'bondingThroughAdversity')![0], 1],
-  // [_.find(_marsEvents, e => e[0].id === 'lifeAsUsual')![0], 1],
+  [_.find(_marsEvents, e => e[0].id === 'sandstorm')![0], 1],
+  [_.find(_marsEvents, e => e[0].id === 'compulsivePhilanthropy')![0], 1],
+  [_.find(_marsEvents, e => e[0].id === 'outOfCommissionCurator')![0], 1],
+  [_.find(_marsEvents, e => e[0].id === 'outOfCommissionPolitician')![0], 1],
+  [_.find(_marsEvents, e => e[0].id === 'outOfCommissionResearcher')![0], 1],
+  [_.find(_marsEvents, e => e[0].id === 'outOfCommissionPioneer')![0], 1],
+  [_.find(_marsEvents, e => e[0].id === 'outOfCommissionEntrepreneur')![0], 1],
+  [_.find(_marsEvents, e => e[0].id === 'audit')![0], 1],
+  [_.find(_marsEvents, e => e[0].id === 'bondingThroughAdversity')![0], 1],
+  [_.find(_marsEvents, e => e[0].id === 'lifeAsUsual')![0], 1],
   [_.find(_marsEvents, e => e[0].id === 'breakdownOfTrust')![0], 1],
 ];
 

--- a/server/src/rooms/game/events/index.ts
+++ b/server/src/rooms/game/events/index.ts
@@ -211,13 +211,14 @@ export class EnteredMarsEventPhase extends KindOnlyGameEvent {
     game.upkeep = game.nextRoundUpkeep();
 
     // system health - contributed upkeep
-    game.log(`Your group invested a total of ${contributedUpkeep} into System Health during the last round.`, `SYSTEM HEALTH`);
+    game.log(`Your group invested a total of ${contributedUpkeep} into System Health during the last round.`,`SYSTEM HEALTH`);
 
     // system health - wear and tear
     game.log(`Standard wear and tear reduced System Health by 25.`, `SYSTEM HEALTH`);
 
     // current system health
-    game.log(`System Health is currently ${game.upkeep}.`,`SYSTEM HEALTH`);
+    game.log(`System Health is currently ${game.upkeep}.`,
+    `SYSTEM HEALTH- ${oldUpkeep < game.upkeep ? 'GAIN' : 'DROP'}`);
 
     game.resetPlayerReadiness();
     game.resetPlayerContributedUpkeep();

--- a/server/src/rooms/game/state/marsEvents/state.ts
+++ b/server/src/rooms/game/state/marsEvents/state.ts
@@ -54,7 +54,7 @@ export abstract class BaseEvent implements MarsEventState {
 export class Sandstorm extends BaseEvent {
   finalize(game: GameState): void {
     game.upkeep -= 10;
-    game.log('A sandstorm has decreased system health by 10.', 'Mars Event');
+    game.log('A sandstorm has decreased system health by 10.', 'Mars Event- Sandstorm');
   }
 }
 
@@ -151,7 +151,7 @@ export class PersonalGain extends BaseEvent {
     game.subtractUpkeep(subtractedUpkeep);
 
     const message = `System health decreased by ${this.subtractedUpkeepTotal(subtractedUpkeep)}. The following players voted yes: ${this.playersVoteYes(this.votes)}`;
-    game.log(message, 'Mars Event');
+    game.log(message, 'Mars Event- Personal Gain');
   }
 
   getData() {
@@ -213,7 +213,7 @@ export class CompulsivePhilanthropy extends BaseEvent {
     game.players[winner].timeBlocks = 0;
     game.log(
       `The ${winner} was voted to be Compulsive Philanthropist with ${count} votes. The ${winner} invested all of their timeblocks into System Health.`,
-      'Mars Event'
+      'Mars Event- Complulsive Philanthropy'
     );
   }
 
@@ -252,7 +252,7 @@ abstract class OutOfCommission extends BaseEvent {
     game.players[role].timeBlocks = 3;
     game.log(
       `${this.player} has 3 timeblocks to invest during this round.`,
-      'Mars Event'
+      'Mars Event- Out Of Commission'
     );
   }
 
@@ -314,7 +314,7 @@ export class Audit extends BaseEvent {
   finalize(game: GameState) {
     game.log(
       `You will be able to view other players' resources. Hover over each player tab on the right to reveal their inventory.`,
-      'Mars Event'
+      'Mars Event- Audit'
     );
   }
 }
@@ -368,7 +368,7 @@ export class BondingThroughAdversity extends BaseEvent {
 
     }
     const message = `Players have gained one influence currency of their choice.`
-    game.log(message, 'Mars Event');
+    game.log(message, 'Mars Event- Bonding Through Adversity');
   }
 
   /**
@@ -390,7 +390,7 @@ export class ChangingTides extends BaseEvent {
     }
     game.log(
       'Each player discards their current Accomplishments and draws one new Accomplishment.',
-      'Mars Event'
+      'Mars Event- Changing Tides'
     );
   }
 }


### PR DESCRIPTION
- mars log reads in reverse chronological order (client)
- added mars log entry number (client)
- added a drop/gain color difference for net change in upkeep (server)
- added headers for mars events (e.x- Mars Event- Sandstorm) (server)
- added background coloring for Mars Event logs (client)

close #350 