### PR TITLE
fix: current element null when switching phases

### DIFF
--- a/client/src/api/tutorial/steps/discard.ts
+++ b/client/src/api/tutorial/steps/discard.ts
@@ -15,7 +15,6 @@ const steps: Array<Step> = [
       {
         SET_LAYOUT: 'tutorial',
         SET_GAME_PHASE: Phase.discard,
-        required: true
       }
     ]
   },

--- a/client/src/views/Tutorial.vue
+++ b/client/src/views/Tutorial.vue
@@ -240,11 +240,14 @@ export default class Tutorial extends Vue {
     this.currentOptionIndex = -1;
     this.quizQuestionStatusMessage = '';
     this.quizQuestionStatus = false;
-    this.api.statePush(this.steps[currentStep + 1].stateTransform);
-    await this.$nextTick();
+    
     const currentStepElement = this.$el.querySelector(
       this.steps[currentStep].target
     );
+
+    this.api.statePush(this.steps[currentStep + 1].stateTransform);
+    await this.$nextTick();
+
     const nextStepElement = this.$el.querySelector(
       this.steps[currentStep + 1].target
     );


### PR DESCRIPTION
the problem occurred anytime the current element was an element only visible in phase X, and the next step switched to phase Y.

Because of the order of operations, currentElement was getting looked at after the phase switch, so it did not exist. 
