### PR TITLE
fix:unable to discard in tutorial

### DIFF
--- a/client/src/api/tutorial/steps/discard.ts
+++ b/client/src/api/tutorial/steps/discard.ts
@@ -14,6 +14,25 @@ const steps: Array<Step> = [
     stateTransform: [
       {
         SET_GAME_PHASE: Phase.discard,
+        SET_ACTIVE_ACCOMPLISHMENTS: {
+          data: {
+            id: 6,
+            role: 'Researcher',
+            label: 'Card you cannot currently purchase',
+            flavorText:
+              'Dummy card that you should throw away!',
+            science: 3,
+            government: 1,
+            legacy: 0,
+            finance: 0,
+            culture: 0,
+            upkeep: 0,
+            victoryPoints: 1,
+            effect:
+              'none'
+          },
+          role: 'Researcher'
+        }
       }
     ]
   },
@@ -26,25 +45,6 @@ const steps: Array<Step> = [
     stateTransform: [
       {
         required: true,
-        SET_ACTIVE_ACCOMPLISHMENTS: {
-          data: {
-            id: 6,
-            role: 'Researcher',
-            label: 'Highly Specialized',
-            flavorText:
-              'You\'re solely focused on your research, to the exclusion of all other pursuits.',
-            science: 3,
-            government: 0,
-            legacy: 0,
-            finance: 0,
-            culture: 0,
-            upkeep: 0,
-            victoryPoints: 1,
-            effect:
-              'You can no longer make Politics or Legacy Influence. Science Influence only costs 1 Time Block to make.'
-          },
-          role: 'Researcher'
-        }
       }
     ]
   },

--- a/client/src/api/tutorial/steps/trade.ts
+++ b/client/src/api/tutorial/steps/trade.ts
@@ -11,6 +11,19 @@ const steps: Array<Step> = [
 
     stateTransform: [
       {
+        SET_PENDING_INVESTMENTS: {
+          data: {
+            culture: 0,
+            finance: 0,
+            government: 0,
+            legacy: 0,
+            science: 0,
+            upkeep: 0
+          },
+          role: RESEARCHER
+        }
+      },
+      {
         SET_GAME_PHASE: Phase.trade
       },
       {


### PR DESCRIPTION
pending inventory wasn't getting reset.

also, technically, it wasn't a bug because in the step that requires you to discard an accomplishment before moving on, a new card is generated. 

This may have looked weird because you could purchase the generated card too, but it wanted you to discard it.

To fix, pending investments are reset.
Also, that generated card is unable to be purchased. 

So, in the discard phase, you should always have two cards you can discard, though you only need to discard one.

should close #422 