### PR TITLE
feat: set up proper user onboarding flow

### DIFF
--- a/client/src/store/mutations/index.ts
+++ b/client/src/store/mutations/index.ts
@@ -8,6 +8,7 @@ import player from './player';
 import trading from './trading';
 import ui from './ui';
 import { State, getInitialStoreState } from '@port-of-mars/client/store/state';
+import { ServerErrorMessage } from '@port-of-mars/shared/types';
 
 export default {
   RESET_STATE(state: State, options?: any) {
@@ -16,6 +17,14 @@ export default {
 
   SET_LAYOUT(state: any, newLayout: string) {
     state.layout = newLayout;
+  },
+
+  SET_ERROR_MESSAGE(state: any, payload: ServerErrorMessage) {
+    state.errors.push(payload);
+  },
+
+  DISMISS_ERROR_MESSAGE(state: any, index: number) {
+    state.errors.splice(index, 1);
   },
 
   SET_ENVIRONMENT(state: any, newEnvironment: string) {

--- a/client/src/store/state.ts
+++ b/client/src/store/state.ts
@@ -20,6 +20,7 @@ import {
   ModalDataType,
 } from '@port-of-mars/client/types/modals';
 import _ from 'lodash';
+import { ServerErrorMessage } from '@port-of-mars/shared/types';
 
 export interface PlayerClientData extends PlayerData {
   pendingInvestments: InvestmentData;
@@ -138,6 +139,7 @@ export interface PopupView {
 export interface State extends GameData {
   role: Role;
   logs: Array<MarsLogMessageData>;
+  errors: Array<ServerErrorMessage>;
   players: PlayerClientSet;
   phase: Phase;
   layout: string;
@@ -204,6 +206,8 @@ export const initialStoreState: State = {
       data: null,
     },
   },
+
+  errors: [],
 
   ui: {
     // TODO: Still needs to be refactored

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -28,7 +28,7 @@
                     <h3 v-if="errors.length > 0">
                         Errors
                     </h3>
-                    <b-alert v-for="(error, index) in errors" :key="error.message" @dismissed="dismissError(index)" variant="danger" dismissible>
+                    <b-alert v-for="(error, index) in errors" :key="error.message" @dismissed="dismissError(index)" variant="danger" dismissible show="true">
                         {{ error.message }}
                     </b-alert>
                 </div>
@@ -36,7 +36,7 @@
                     <p>Action Items are loading...</p>
                 </div>
                 <div v-else>
-                    <div v-for="(action,index) in actionItems" :key="action.link" class="action-item">
+                    <div v-for="action in actionItems" class="action-item">
                         <p>{{action.description}}</p>
                         <BButton squared class="button" variant="dark" :to="action.link.data" v-if="isInternal(action.link)">Go</BButton>
                         <BButton squared class="button" variant="dark" :href="action.link.data" v-else>Go</BButton>
@@ -93,11 +93,11 @@ export default class PlayerDashboard extends Mixins(Vue, DashboardAPI) {
     }
 
     get errors() {
-        return this.$tstore.state.errors;
+      return this.$tstore.state.errors;
     }
 
     dismissError(index: number) {
-        this.$tstore.commit('DISMISS_ERROR_MESSAGE', index);
+      this.$tstore.commit('DISMISS_ERROR_MESSAGE', index);
     }
 
     get joinLink() {

--- a/client/src/views/Dashboard.vue
+++ b/client/src/views/Dashboard.vue
@@ -24,12 +24,19 @@
 
             <div class="bottom">
                 <h2>Action Items</h2>
+                <div class="error-messages">
+                    <h3 v-if="errors.length > 0">
+                        Errors
+                    </h3>
+                    <b-alert v-for="(error, index) in errors" :key="error.message" @dismissed="dismissError(index)" variant="danger" dismissible>
+                        {{ error.message }}
+                    </b-alert>
+                </div>
                 <div v-if="loading">
                     <p>Action Items are loading...</p>
                 </div>
-
                 <div v-else>
-                    <div v-for="(action,index) in actionItems" :key="index" class="action-item">
+                    <div v-for="(action,index) in actionItems" :key="action.link" class="action-item">
                         <p>{{action.description}}</p>
                         <BButton squared class="button" variant="dark" :to="action.link.data" v-if="isInternal(action.link)">Go</BButton>
                         <BButton squared class="button" variant="dark" :href="action.link.data" v-else>Go</BButton>
@@ -73,7 +80,7 @@ export default class PlayerDashboard extends Mixins(Vue, DashboardAPI) {
     private upcomingGames: Array<GameMeta> = [];
 
     async mounted(){
-        await this.initialize();
+      await this.initialize();
     }
 
     async initialize() {
@@ -83,6 +90,14 @@ export default class PlayerDashboard extends Mixins(Vue, DashboardAPI) {
       this.stats.games.splice(0, this.stats.games.length, ...data.stats.games);
       this.upcomingGames.splice(0, this.upcomingGames.length, ...data.upcomingGames);
       this.loading = false;
+    }
+
+    get errors() {
+        return this.$tstore.state.errors;
+    }
+
+    dismissError(index: number) {
+        this.$tstore.commit('DISMISS_ERROR_MESSAGE', index);
     }
 
     get joinLink() {

--- a/server/src/routes/dashboard.ts
+++ b/server/src/routes/dashboard.ts
@@ -20,10 +20,10 @@ dashboardRouter
   //this route is only for testing. it will be removed when the registration method is complete
   .get('/createInvite', async (req, res, next) => {
     try {
-      const registration = getServices().registration;
+      const tournament = getServices().tournament;
 
       //assuming the round number is 1
-      await registration.createInvites([(req.user as User).id], 1);
+      await tournament.createInvites([(req.user as User).id], 1);
 
       res.json({ "created invite for ": (req.user as User).id })
 

--- a/server/src/routes/dashboard.ts
+++ b/server/src/routes/dashboard.ts
@@ -1,33 +1,35 @@
-import {Router, Request, Response} from 'express';
+import { Router, Request, Response } from 'express';
 import { getServices } from '@port-of-mars/server/services';
 import { User } from '@port-of-mars/server/entity/User';
+import { isAuthenticated } from '@port-of-mars/server/routes/middleware';
 
 export const dashboardRouter = Router();
 
+dashboardRouter.use(isAuthenticated);
+
 dashboardRouter
-.get('/', async (req, res, next) => {
-  try{
-    const dashboard = await getServices().dashboard.getData(req.user as User);
-    res.json(dashboard);
-  }
-  catch(e){
-    next(e);
-  }
-  
-})
-//this route is only for testing. it will be removed when the registration method is complete
-.get('/createInvite', async (req,res,next) => {
-  try{
-    const registration = getServices().registration;
+  .get('/', async (req: Request, res: Response, next) => {
+    try {
+      const dashboard = await getServices().dashboard.getData(req.user as User);
+      res.json(dashboard);
+    }
+    catch (e) {
+      next(e);
+    }
+  })
+  //this route is only for testing. it will be removed when the registration method is complete
+  .get('/createInvite', async (req, res, next) => {
+    try {
+      const registration = getServices().registration;
 
-    //assuming the round number is 1
-    await registration.createInvites([(req.user as User).id],1);
+      //assuming the round number is 1
+      await registration.createInvites([(req.user as User).id], 1);
 
-    res.json({"created invite for ":(req.user as User).id})
+      res.json({ "created invite for ": (req.user as User).id })
 
-  }
-  catch(e){
-    next(e);
-  }
-});
+    }
+    catch (e) {
+      next(e);
+    }
+  });
 

--- a/server/src/routes/game.ts
+++ b/server/src/routes/game.ts
@@ -1,22 +1,29 @@
-import {Router} from "express";
-import {getServices} from "@port-of-mars/server/services";
-import {User} from "@port-of-mars/server/entity";
-import {settings} from "@port-of-mars/server/settings";
+import { Router } from "express";
+import { getServices } from "@port-of-mars/server/services";
+import { User } from "@port-of-mars/server/entity";
+import { settings } from "@port-of-mars/server/settings";
+import { ServerErrorMessage } from "@port-of-mars/shared/types";
+import { isVerified } from "@port-of-mars/server/routes/middleware";
 
 const logger = settings.logging.getLogger(__filename);
 
 export const gameRouter = Router();
 
+gameRouter.use(isVerified);
+
 gameRouter.get('/latest-active', async (req, res, next) => {
   try {
-    const user = req.user as User | undefined;
-    if (!user) {
-      res.status(401).json();
-      return;
+    const user = req.user as User;
+    const roomId = await getServices().game.getActiveGameRoomId(user.id);
+    if (roomId) {
+      logger.info('found active game with roomId %s for user %o', roomId, user);
+      res.json(roomId);
     }
-    const roomId = await getServices().game.getLatestActiveGameByUserId((user).id);
-    logger.info('found active game with roomId', roomId, 'for user', user);
-    res.json(roomId);
+    else {
+      const message: ServerErrorMessage = { message: 'Did not find an active game.' }
+      logger.info('no game room for user %o', user);
+      res.status(404).json(message);
+    }
   } catch (e) {
     next(e);
   }

--- a/server/src/routes/middleware.ts
+++ b/server/src/routes/middleware.ts
@@ -1,21 +1,39 @@
 import { Request, Response } from 'express';
 import { NextFunction } from 'connect';
-import {settings} from '@port-of-mars/server/settings';
+import { settings } from '@port-of-mars/server/settings';
 import _ from 'lodash';
 import { toUrl } from '@port-of-mars/server/util';
 import { LOGIN_PAGE } from '@port-of-mars/shared/routes';
+import { ServerErrorMessage } from '@port-of-mars/shared/types';
+import { User } from '@port-of-mars/server/entity';
 
 const logger = settings.logging.getLogger(__filename);
 
-export function auth(req: Request, res: Response, next: NextFunction) {
+export function isAuthenticated(req: Request, res: Response, next: NextFunction) {
   if (_.isUndefined(req.user)) {
     const loginUrl = toUrl(LOGIN_PAGE);
-    logger.trace('no user on the request, redirecting to login page: ', loginUrl)
-    res.status(404).send();
-
-    // res.redirect(loginUrl);
+    logger.trace('no user on the request, redirecting to login page: %s', loginUrl)
+    res.redirect(loginUrl);
   }
   else {
     next();
+  }
+}
+
+export function isVerified(req: Request, res: Response, next: NextFunction) {
+  if (_.isUndefined(req.user)) {
+    const loginUrl = toUrl(LOGIN_PAGE);
+    logger.trace('no user on the request, redirecting to login page: %s', loginUrl);
+    res.redirect(loginUrl);
+  }
+  else {
+    const verified = (req.user as User).isVerified;
+    if (verified) {
+      return next();
+    }
+    else {
+      const message: ServerErrorMessage = { message: 'Please verify your account before proceeding.' };
+      return res.status(403).json(message);
+    }
   }
 }

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -38,7 +38,7 @@ export class DashboardService extends BaseService {
   }
 
   async getCurrentGameActionItem(user: User): Promise<ActionItem | undefined> {
-    const roomId = await this.sp.game.getLatestActiveGameByUserId(user.id);
+    const roomId = await this.sp.game.getActiveGameRoomId(user.id);
     if (!roomId) {
       return;
     }

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -94,7 +94,7 @@ export class DashboardService extends BaseService {
     if (!user.passedQuiz) {
       actionItems.push(this.getPassedTutorialActionItem(user));
     } else {
-      const invite = await this.sp.tournament.getActiveRoundInvite(user.id, round.id);
+      const invite = await this.sp.tournament.getActiveRoundInvite(user.id, round);
       actionItems.push(this.getCompletedIntroSurveyActionItem(round, invite));
 
       const gameActionItem = await this.getCurrentGameActionItem(user);

--- a/server/src/services/email/emailers.ts
+++ b/server/src/services/email/emailers.ts
@@ -32,7 +32,7 @@ export class MailgunEmailer implements Emailer {
       auth.domain = 'example.com';
     }
     this.opts = { auth }
-    this.transport = nodemailer.createTransport(mailgunTransport({ auth }));
+    this.transport = nodemailer.createTransport(mailgunTransport(this.opts));
   }
 
   sendMail(content: Mail.Options) {

--- a/server/src/services/game.ts
+++ b/server/src/services/game.ts
@@ -7,7 +7,7 @@ export class GameService extends BaseService {
     return await this.em.getRepository(Game).findOneOrFail({id});
   }
 
-  async getActiveGameRoomId(userId: number): Promise<Game | undefined> {
+  async getActiveGameRoomId(userId: number): Promise<string | undefined> {
     const game = await this.em.getRepository(Game).findOne({
         where: {
           players: {

--- a/server/src/services/game.ts
+++ b/server/src/services/game.ts
@@ -7,8 +7,8 @@ export class GameService extends BaseService {
     return await this.em.getRepository(Game).findOneOrFail({id});
   }
 
-  async getLatestActiveGameByUserId(userId: number): Promise<string | undefined> {
-    const g = await this.em.getRepository(Game).findOne({
+  async getActiveGameRoomId(userId: number): Promise<Game | undefined> {
+    const game = await this.em.getRepository(Game).findOne({
         where: {
           players: {
             user: {
@@ -22,6 +22,6 @@ export class GameService extends BaseService {
         }
       }
     );
-    return g?.roomId;
+    return game?.roomId;
   }
 }

--- a/server/src/services/registration.ts
+++ b/server/src/services/registration.ts
@@ -18,11 +18,6 @@ export class RegistrationService extends BaseService {
     return await this.em.getRepository(User).findOne({ registrationToken })
   }
 
-  async createInvites(userIds: Array<number>, tournamentRoundId: number): Promise<Array<TournamentRoundInvite>> {
-    const invites = userIds.map(userId => this.em.getRepository(TournamentRoundInvite).create({ userId, tournamentRoundId }));
-    return await this.em.getRepository(TournamentRoundInvite).save(invites);
-  }
-
   async sendEmailVerification(u: User): Promise<void> {
     const link = this.createRegistrationURL(u.registrationToken);
     settings.emailer.sendMail({

--- a/server/src/services/tournament.ts
+++ b/server/src/services/tournament.ts
@@ -72,7 +72,7 @@ export class TournamentService extends BaseService {
       invite = await this.createInvite(userId, tournamentRoundId)
     }
     else {
-      throw new EntityNotFoundError(`User ${userId} does not have an invite for the current round ${tournamentRoundId}.`);
+      throw new EntityNotFoundError(TournamentRoundInvite, `User ${userId} does not have an invite for the current round ${tournamentRoundId}.`);
     }
     return invite;
   }

--- a/server/tests/services/tournament.test.ts
+++ b/server/tests/services/tournament.test.ts
@@ -41,7 +41,7 @@ describe('first round', () => {
       await services.quiz.setUserQuizCompletion(bob.id, true);
       expect(await services.auth.checkUserCanPlayGame(bob.id, tr.id)).toBeFalsy();
 
-      const invites = await services.registration.createInvites([bob.id], tr.id);
+      const invites = await services.tournament.createInvites([bob.id], tr.id);
       expect(await services.auth.checkUserCanPlayGame(bob.id, tr.id)).toBeTruthy();
 
       await services.quiz.setUserQuizCompletion(bob.id, true);

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -245,4 +245,8 @@ export interface DashboardData {
   stats: Stats
 }
 
+export interface ServerErrorMessage {
+  message: string
+}
+
 export type RoomId = string;


### PR DESCRIPTION
work in progress to improve how we handle server side authentication /
authorization and tournament round checking

- standardize responses between the client / server
- WIP to automagically create a tournament round invite in the first
round of the tournament for incoming users
- player should always be able to get to their dashboard and see what
they need to be doing (verify their email address, take the intro
survey, go to the tutorial)