### PR TITLE
feat: Animations for purchase/discard

### DIFF
--- a/client/src/components/game/phases/Discard.vue
+++ b/client/src/components/game/phases/Discard.vue
@@ -18,10 +18,11 @@
         <div class="outer-wrapper">
           <div class="wrapper">
             <AccomplishmentCard
-              v-for="accomplishment in purchasableAccomplishments"
+              v-for="accomplishment in staticAccomplishments"
               :key="accomplishment.label + 2"
               :accomplishment="accomplishment"
               :type="cardType"
+              :showCard="wasDiscarded(accomplishment.id)"
             />
           </div>
         </div>
@@ -45,9 +46,7 @@ import { AccomplishmentData } from '@port-of-mars/shared/types';
   },
 })
 export default class Discard extends Vue {
-  get purchasableAccomplishments() {
-    return this.$store.getters.player.accomplishments.purchasable
-      .slice()
+  private staticAccomplishments = this.$store.getters.player.accomplishments.purchasable.slice()
       .sort((a: AccomplishmentData, b: AccomplishmentData) => {
         return (
           Number(
@@ -58,6 +57,12 @@ export default class Discard extends Vue {
           )
         );
       });
+
+  wasDiscarded(id: number){
+    console.log(this.$store.getters.player.accomplishments.purchasable)
+    return Boolean((this.$store.getters.player.accomplishments.purchasable as Array<AccomplishmentData>)
+      .slice()
+      .filter(accomplishment => accomplishment.id == id).length > 0);
   }
 
   get cardType() {

--- a/client/src/components/game/phases/Purchase.vue
+++ b/client/src/components/game/phases/Purchase.vue
@@ -18,10 +18,11 @@
         <div class="outer-wrapper">
           <div class="wrapper">
             <AccomplishmentCard
-              v-for="accomplishment in purchasableAccomplishments"
+              v-for="accomplishment in staticAccomplishments"
               :key="accomplishment.label + 2"
               :accomplishment="accomplishment"
               :type="cardType"
+              :showCard="wasPurchased(accomplishment.id)"
             />
           </div>
         </div>
@@ -45,9 +46,7 @@ import { AccomplishmentData } from '@port-of-mars/shared/types';
   },
 })
 export default class Purchase extends Vue {
-  get purchasableAccomplishments() {
-    let accomplishments = this.$store.getters.player.accomplishments.purchasable
-      .slice()
+  private staticAccomplishments = this.$store.getters.player.accomplishments.purchasable.slice()
       .sort((a: AccomplishmentData, b: AccomplishmentData) => {
         return (
           Number(
@@ -59,7 +58,11 @@ export default class Purchase extends Vue {
         );
       });
 
-    return accomplishments;
+  wasPurchased(id: number){
+    console.log(this.$store.getters.player.accomplishments.purchasable)
+    return Boolean((this.$store.getters.player.accomplishments.purchasable as Array<AccomplishmentData>)
+      .slice()
+      .filter(accomplishment => accomplishment.id == id).length > 0);
   }
 
   get cardType() {

--- a/client/src/stylesheets/game/accomplishments/AccomplishmentCard.scss
+++ b/client/src/stylesheets/game/accomplishments/AccomplishmentCard.scss
@@ -12,7 +12,9 @@
   .info-wrapper,
   .cost-wrapper,
   .purchase-wrapper,
-  .discard-wrapper {
+  .discard-wrapper,
+  .status-text {
+    @include default-transition-base;
     width: 100%;
     padding: 0.5rem;
     margin: 0;
@@ -43,7 +45,7 @@
         margin-bottom: 0;
         font-size: $font-med;
         font-weight: $font-weight-maven-pro-medium;
-        color: $space-gray;
+        //color: $space-gray;
         text-align: center;
         @include text-overflow-ellipses;
       }
@@ -126,6 +128,11 @@
       @include make-center;
     }
   }
+
+  .status-text {
+    background-color: $space-gray;
+    text-align: center;
+  }
 }
 
 .default {
@@ -156,5 +163,44 @@
   .purchase button,
   .discard button {
     @include space-button-white;
+  }
+}
+
+.discarded {
+  @include default-transition-base;
+  border: 0.125rem solid $status-red;
+  background-color: $status-red;
+
+  .text{
+    color: $status-red;
+    font-size: $font-med;
+    font-weight: bold;
+  }
+}
+
+.purchased {
+  @include default-transition-base;
+  border: 0.125rem solid $status-green;
+  background-color: $status-green;
+
+  .text{
+    color: $status-green;
+    font-size: $font-med;
+    font-weight: bold;
+  }
+}
+
+.hide-card{
+  animation: hide 0.3s linear 1.5s 1 forwards;
+}
+
+@keyframes hide{
+  0%{
+    opacity: 100%;
+  }
+
+  100%{
+    opacity: 0;
+    height:0;
   }
 }


### PR DESCRIPTION
I chose to do these on entirely on the client side.  We have so much context surrounding each action, it felt like a lot of unnecessary work to add a tag to each accomplishment and then track that tag through each cycle of that accomplishment's life. 

should close #449 