### PR TITLE
fix: event/accomplishment modal styles

### DIFF
--- a/client/src/api/tutorial/request.ts
+++ b/client/src/api/tutorial/request.ts
@@ -189,8 +189,10 @@ export class TutorialAPI  {
 
   //MODAL HANDLERS
   public setModalVisible(data: any){
-    this.store.commit('SET_MODAL_VISIBLE',data);
-    this.completedActionWithImplicitForward();
+    if(data.data.activator != 'Server'){
+      this.store.commit('SET_MODAL_VISIBLE',data);
+      this.completedActionWithImplicitForward();
+    }
   }
 
   public setModalHidden(){

--- a/client/src/components/game/accomplishments/AccomplishmentCard.vue
+++ b/client/src/components/game/accomplishments/AccomplishmentCard.vue
@@ -3,7 +3,7 @@
     <div class="title-wrapper row">
       <div class="title col-12">
         <p :style="fontColor">{{ accomplishment.label }}</p>
-        <font-awesome-icon
+        <font-awesome-icon v-if="!isModal"
           :icon="['fas', 'info-circle']"
           size="lg"
           @click="handleClick"

--- a/client/src/components/game/accomplishments/AccomplishmentCard.vue
+++ b/client/src/components/game/accomplishments/AccomplishmentCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="c-accomplishmentcard" :class="cardTypeStyling" v-show="cardIsActive">
+  <div class="c-accomplishmentcard" :class="[cardTypeStyling, {'modal-view':isModal}]" v-show="cardIsActive">
     <div class="title-wrapper row">
       <div class="title col-12">
         <p :style="fontColor">{{ accomplishment.label }}</p>
@@ -134,6 +134,9 @@ export default class AccomplishmentCard extends Vue {
 
   private cardIsActive:boolean = true;
 
+  @Prop({default: false})
+  private isModal!:boolean;
+
   // NOTE :: All / Default Type
 
   @Watch('showCard', {immediate: true})
@@ -200,6 +203,7 @@ export default class AccomplishmentCard extends Vue {
 
     return {color: 'black'}
   }
+
 
   // NOTE :: Purchase Type
 

--- a/client/src/components/game/modals/CardModal.vue
+++ b/client/src/components/game/modals/CardModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="card-modal container">
-    <div class="title-wrapper row">
+    <!-- <div class="title-wrapper row">
       <div class="title col-12">
         <p>{{ modalData.title }}</p>
       </div>
@@ -9,7 +9,7 @@
       <div class="content col-12">
         <p>{{ modalData.content }}</p>
       </div>
-    </div>
+    </div> -->
     <div class="cards-wrapper row">
       <div class="cards col-12">
         <AccomplishmentCard
@@ -29,10 +29,11 @@
     </div>
     <div v-if="modalData.confirmation" class="confirm-wrapper row">
       <div class="confirm col-12">
+        <p class="confirm-text">Are you sure you want do proceed? </p>
         <button @click="handleConfirmation">Confirm</button>
       </div>
     </div>
-    <div v-if="!modalData.confirmation" class="ghost-wrapper row"></div>
+    <!-- <div v-if="!modalData.confirmation" class="ghost-wrapper row"></div> -->
   </div>
 </template>
 

--- a/client/src/components/game/modals/CardModal.vue
+++ b/client/src/components/game/modals/CardModal.vue
@@ -17,6 +17,7 @@
           class="accomplishment-card"
           :key="modalData.cardData.id"
           :accomplishment="modalData.cardData"
+          :isModal="true"
         />
         <EventCard
           v-else-if="modalData.cardType === 'EventCard'"

--- a/client/src/components/game/modals/CardModal.vue
+++ b/client/src/components/game/modals/CardModal.vue
@@ -1,15 +1,5 @@
 <template>
   <div class="card-modal container">
-    <!-- <div class="title-wrapper row">
-      <div class="title col-12">
-        <p>{{ modalData.title }}</p>
-      </div>
-    </div>
-    <div class="content-wrapper row">
-      <div class="content col-12">
-        <p>{{ modalData.content }}</p>
-      </div>
-    </div> -->
     <div class="cards-wrapper row">
       <div class="cards col-12">
         <AccomplishmentCard
@@ -25,6 +15,8 @@
           :key="modalData.cardData.id"
           :event="modalData.cardData"
           :visible="true"
+          :isModal="true"
+          :wasSpawnedByServer="serverCreated(modalData.activator)"
         />
       </div>
     </div>
@@ -80,6 +72,10 @@ export default class CardModal extends Vue {
       this.api.discardAccomplishment(this.modalData.cardData.id as number);
     }
     this.api.setModalHidden();
+  }
+
+  private serverCreated(activator:string){
+    return activator == 'Server';
   }
 }
 </script>

--- a/client/src/components/game/phases/Events.vue
+++ b/client/src/components/game/phases/Events.vue
@@ -60,11 +60,12 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Watch } from 'vue-property-decorator';
+import { Vue, Component, Watch, Inject } from 'vue-property-decorator';
 import EventCard from './events/EventCard.vue';
 import EventContainer from './events/events/EventContainer.vue';
 import AccomplishmentCard from '@port-of-mars/client/components/game/accomplishments/AccomplishmentCard.vue';
 import { MarsEventData, Phase } from '@port-of-mars/shared/types';
+import { GameRequestAPI } from '@port-of-mars/client/api/game/request';
 
 @Component({
   components: {
@@ -74,6 +75,8 @@ import { MarsEventData, Phase } from '@port-of-mars/shared/types';
   },
 })
 export default class Events extends Vue {
+  @Inject() readonly api!: GameRequestAPI;
+
   private selectedView: string = 'Event Deck';
 
   // NOTE :: LIFECYCLE HOOKS & WATCHERS
@@ -90,6 +93,22 @@ export default class Events extends Vue {
     if (this.selectedView === 'Active Accomplishments') {
       this.selectedView = 'Event Deck';
     }
+  }
+
+  //Open an event modal when a new card comes in
+  @Watch('currentEvent',{immediate:true})
+  onNewEvent(event:any){
+    this.api.setModalVisible({
+      type: 'CardModal',
+      data: {
+        activator: 'Server',
+        title: 'Event',
+        content: 'This is a description of the Event.',
+        cardType: 'EventCard',
+        cardData: event,
+        confirmation: false,
+      },
+    });
   }
 
   // NOTE :: EVENT SPECIFIC

--- a/client/src/stylesheets/game/accomplishments/AccomplishmentCard.scss
+++ b/client/src/stylesheets/game/accomplishments/AccomplishmentCard.scss
@@ -194,6 +194,10 @@
   }
 }
 
+.modal-view{
+  border:none;
+}
+
 .hide-card{
   animation: hide 0.3s linear 1.5s 1 forwards;
 }

--- a/client/src/stylesheets/game/accomplishments/AccomplishmentCard.scss
+++ b/client/src/stylesheets/game/accomplishments/AccomplishmentCard.scss
@@ -1,9 +1,11 @@
 .c-accomplishmentcard {
   width: 100%;
   padding: 0;
+  height: 100%;
   margin: 0 0 0.5rem 0;
   @include make-column-and-center;
-  flex-shrink: 0;
+  //flex-shrink: 0;
+  align-items: stretch;
 
   &:last-child {
     margin-bottom: 0;
@@ -55,6 +57,7 @@
 
   .info-wrapper {
     background-color: $space-gray;
+    flex:1;
 
     .points {
       padding: 0 0.5rem;
@@ -71,6 +74,7 @@
     }
 
     .flavortext {
+      flex:1;
       padding: 0 0.5rem;
 
       p {
@@ -84,6 +88,7 @@
   }
 
   .cost-wrapper {
+    flex:1;
     background-color: $space-gray;
 
     .cost {

--- a/client/src/stylesheets/game/accomplishments/AccomplishmentCard.scss
+++ b/client/src/stylesheets/game/accomplishments/AccomplishmentCard.scss
@@ -6,7 +6,7 @@
   @include make-column-and-center;
   //flex-shrink: 0;
   align-items: stretch;
-
+  max-height: 17rem !important;
   &:last-child {
     margin-bottom: 0;
   }

--- a/client/src/stylesheets/game/accomplishments/AccomplishmentCard.scss
+++ b/client/src/stylesheets/game/accomplishments/AccomplishmentCard.scss
@@ -1,12 +1,11 @@
 .c-accomplishmentcard {
   width: 100%;
   padding: 0;
-  height: 100%;
+  //height: 100%;
   margin: 0 0 0.5rem 0;
   @include make-column-and-center;
-  //flex-shrink: 0;
-  align-items: stretch;
-  max-height: 17rem !important;
+  flex-shrink: 0;
+  //align-items: stretch;
   &:last-child {
     margin-bottom: 0;
   }
@@ -57,7 +56,7 @@
 
   .info-wrapper {
     background-color: $space-gray;
-    flex:1;
+    //flex:1;
 
     .points {
       padding: 0 0.5rem;
@@ -74,7 +73,7 @@
     }
 
     .flavortext {
-      flex:1;
+      //flex:1;
       padding: 0 0.5rem;
 
       p {
@@ -88,7 +87,7 @@
   }
 
   .cost-wrapper {
-    flex:1;
+    //flex:1;
     background-color: $space-gray;
 
     .cost {
@@ -196,6 +195,7 @@
 
 .modal-view{
   border:none;
+  max-height: 17rem !important;
 }
 
 .hide-card{

--- a/client/src/stylesheets/game/modals/CardModal.scss
+++ b/client/src/stylesheets/game/modals/CardModal.scss
@@ -1,6 +1,6 @@
 .card-modal {
-  height: 25rem;
-  width: 35rem;
+  height: 20rem;
+  width: 50rem;
   @include reset-padding-margin;
   border: 0.125rem solid $space-lightgreen;
   @include make-column-and-top;
@@ -13,7 +13,7 @@
   .confirm-wrapper,
   .ghost-wrapper {
     width: 100%;
-    padding: 0.5rem;
+    //padding: 0.5rem;
     margin: 0;
   }
 
@@ -55,11 +55,14 @@
   .cards-wrapper {
     background-color: $space-white-opaque-1;
     overflow-y: hidden;
+    height:100%;
 
     .cards {
       @include expand;
       padding: 0;
       overflow-y: scroll;
+      @include disable-scroll;
+      height:100%;
     }
   }
 
@@ -70,6 +73,11 @@
       @include expand;
       padding: 0;
       @include make-center;
+      flex-direction: column;
+
+      .confirm-text{
+        color: $space-lightgreen;
+      }
 
       button {
         @include space-button-modal;

--- a/client/src/stylesheets/game/modals/CardModal.scss
+++ b/client/src/stylesheets/game/modals/CardModal.scss
@@ -63,6 +63,7 @@
       overflow-y: scroll;
       @include disable-scroll;
       height:100%;
+      background-color: $space-gray;
     }
   }
 

--- a/client/src/stylesheets/game/phases/events/EventCard.scss
+++ b/client/src/stylesheets/game/phases/events/EventCard.scss
@@ -98,4 +98,24 @@
       }
     }
   }
+
+  .interact-wrapper {
+    flex:1;
+    background-color: $space-gray;
+    margin-top:4rem;
+    
+    .interact {
+      padding: 0;
+      @include make-center;
+      
+      .button{
+        @include space-button;
+      }
+    }
+  }
+}
+
+.modal-view{
+  border:0;
+  background-color: $space-gray;
 }

--- a/client/src/stylesheets/game/phases/events/EventCard.scss
+++ b/client/src/stylesheets/game/phases/events/EventCard.scss
@@ -1,10 +1,12 @@
 .c-eventcard {
   width: 100%;
   padding: 0;
+  //height:100%;
   border: 0.125rem solid $space-white;
   margin: 0 0 0.5rem 0;
   @include make-column-and-center;
   flex-shrink: 0;
+  align-items: stretch;
 
   &:last-child {
     margin-bottom: 0;
@@ -62,6 +64,7 @@
   }
 
   .flavortext-wrapper {
+    flex:1;
     background-color: $space-gray;
 
     .flavortext {
@@ -79,6 +82,7 @@
   }
 
   .duration-wrapper {
+    flex:1;
     background-color: $space-gray;
 
     .duration {


### PR DESCRIPTION
Accomplishment modals:
- just have the same data as the cards smaller version of the card. there are some cases where this could be useful, the times when the description is not on the small version of the card, but in many cases, it might feel unhelpful and redundant. Maybe we consider removing the info icon entirely, only rendering it when the description can not also fit.

Event Modals:
- have the same data as the card
- when a new event is generated, so is a modal, which brings them front and center, as previously discussed. On events where interaction is necessary, an 'Interact' button appears, which closes the modal. When interaction is not required, a 'Continue' button appears, which sets player readiness and closes the modal

close #447 