### PR TITLE
feat: investment chat message when under audit

### DIFF
--- a/server/src/rooms/game/events/index.ts
+++ b/server/src/rooms/game/events/index.ts
@@ -111,6 +111,24 @@ export class TimeInvested extends GameEventWithData {
 
   apply(game: GameState): void {
     game.investTime(this.data.role, this.data.investment);
+
+    if(game.marsEvents.filter(event => event.id == 'audit').length > 0){
+      const investmentString = Object.keys(this.data.investment)
+      .filter((investment) => {
+        return investment=='upkeep' || this.data.investment[investment as Resource] != 0;
+      })
+      .map((investment) =>{
+          return `${this.data.investment[investment as Resource]} ${investment}`;
+      }).join(', ');
+
+      const message:ChatMessageData = {
+        message: `The ${this.data.role} has purchased ${investmentString}`,
+        role:this.data.role,
+        dateCreated: new Date().getDate(),
+        round:game.round
+      }
+      game.addChat(message);
+    }
   }
 }
 gameEventDeserializer.register(TimeInvested);


### PR DESCRIPTION
This is a start, I think.

When you're under audit, every time you ready up in the investment phase, a chat message is generated with what you bought.

I would love some more clarification on the "show the time investments for that player", as I'm pretty sure we're already doing that, once you leave the investment phase. The reason that value doesn't update as you buy things is because pending investments don't actually get sent to the server until you either ready up or the round ends.

Thanks in advance!