### PR TITLE
fix:breakdown of trust correctly saves timeblocks

### DIFF
--- a/server/src/rooms/game/state/index.ts
+++ b/server/src/rooms/game/state/index.ts
@@ -774,6 +774,10 @@ export class Player extends Schema implements PlayerData {
     this.timeBlocks = amount;
   }
 
+  get currentTimeBlocksAmount(){
+    return this.timeBlocks;
+  }
+
   getLeftOverInvestments() {
     const investment = _.cloneDeep(this.pendingInvestments);
 

--- a/server/src/rooms/game/state/marsEvents/state.ts
+++ b/server/src/rooms/game/state/marsEvents/state.ts
@@ -75,14 +75,24 @@ export class LifeAsUsual extends BaseEvent {
 
 ////////////////////////// BreakdownOfTrust //////////////////////////
 
-export type BreakdownOfTrustData = { [role in Role]: InvestmentData}
+export type BreakdownOfTrustData = { [role in Role]: number}
 
 @assocEventId
 export class BreakdownOfTrust extends BaseEvent {
 
+  //converts the roles array into an object that looks like BreakdownOfTrustData
+  private savedtimeBlockAllocations:BreakdownOfTrustData = ROLES.reduce((obj,role)=>{
+    //these are placeholder values, they will be overridden.
+    obj[role] = 0;
+    return obj;
+  },{} as BreakdownOfTrustData);
+
   initialize(game: GameState){
     for(const player of game.players){
       player.invertPendingInventory();
+      //save the timeblock amount the player is allotted for the round
+      this.savedtimeBlockAllocations[player.role] = player.currentTimeBlocksAmount;
+      //set them to 2 for the event
       player.setTimeBlocks(2);
     }
   }
@@ -94,7 +104,8 @@ export class BreakdownOfTrust extends BaseEvent {
   finalize(game: GameState): void {
     for(const player of game.players){
       player.mergePendingAndInventory();
-      player.resetTimeBlocks();
+      //set that value back to the amount before the event
+      player.timeBlocks = this.savedtimeBlockAllocations[player.role];
     }
 
     game.log(`Each player chooses up to 2 Influence cards they own, then discards the rest.`, `${ MarsLogCategory.event }: ${formatEventName(BreakdownOfTrust.name)}`)

--- a/server/tests/rooms/game/index.test.ts
+++ b/server/tests/rooms/game/index.test.ts
@@ -5,7 +5,7 @@ import * as _ from 'lodash'
 import { mockGameStateInitOpts } from "@port-of-mars/server/util";
 import { canSendTradeRequest } from "@port-of-mars/shared/validation";
 import {
-  OutOfCommissionCurator, OutOfCommissionPioneer, OutOfCommissionResearcher, OutOfCommissionPolitician, OutOfCommissionEntrepreneur
+  OutOfCommissionCurator, OutOfCommissionPioneer, OutOfCommissionResearcher, OutOfCommissionPolitician, OutOfCommissionEntrepreneur, BreakdownOfTrust
 } from "@port-of-mars/server/rooms/game/state/marsEvents/state";
 
 
@@ -224,5 +224,40 @@ describe('out of commission event reduces timeblocks for each role', () => {
     for (const p of g.players) {
       expect(p.timeBlocks).toBe(3);
     }
+  });
+});
+
+describe('Breakdown of trust saves timeBlocks', () => {
+  const g = new GameState(mockGameStateInitOpts(x => x, () => 10));
+
+  it('gives each role 10 timeblocks with no other events active', () => {
+    let breakdownOfTrust = new BreakdownOfTrust();
+    breakdownOfTrust.initialize(g);
+    breakdownOfTrust.finalize(g);
+
+    for (const p of g.players) {
+      expect(p.timeBlocks).toBe(10);
+    }
+  })
+
+  it('gives each role 3 timeblocks when paired with out of commission', () => {
+
+    for (const p of g.players) {
+      expect(p.timeBlocks).toBe(10);
+    }
+    new OutOfCommissionCurator().finalize(g);
+    new OutOfCommissionEntrepreneur().finalize(g);
+    new OutOfCommissionResearcher().finalize(g);
+    new OutOfCommissionPolitician().finalize(g);
+    new OutOfCommissionPioneer().finalize(g);
+
+    let breakdownOfTrust = new BreakdownOfTrust();
+    breakdownOfTrust.initialize(g);
+    breakdownOfTrust.finalize(g);
+
+    for (const p of g.players) {
+      expect(p.timeBlocks).toBe(3);
+    }
+
   });
 });


### PR DESCRIPTION
saves the timeblocks before setting them to two; then sets back to the saved values at the end of the event.

should help with #476 