### PR TITLE
Experimental: use arm64v8 docker images for development on arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ MAIL_API_KEY_PATH=keys/mail_api_key
 SECRETS=$(MAIL_API_KEY_PATH) $(DB_PASSWORD_PATH) $(ORMCONFIG_PATH) $(PGPASS_PATH) $(SENTRY_DSN_PATH) $(SECRET_KEY_PATH)
 SHARED_CONFIG_PATH=shared/src/assets/config.ts
 BUILD_ID=$(shell git describe --tags --abbrev=1)
+POM_DEV_ARCH=$(if $(findstring aarch64,$(shell uname -m)),arm64v8/,)
+
+export POM_DEV_ARCH
 
 .PHONY: build
 build: docker-compose.yml

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:16-bullseye-slim
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 LABEL maintainer="Allen Lee <allen.lee@asu.edu>"
 

--- a/dev.yml
+++ b/dev.yml
@@ -2,6 +2,10 @@ services:
   client:
     build:
       dockerfile: client/Dockerfile
+      args:
+        BASE_IMAGE: node:16-bullseye-slim
+        # FIXME: client doesn't seem to work with arm64v8 image
+        # BASE_IMAGE: ${POM_DEV_ARCH}node:16-bullseye-slim
       context: .
     restart: always
     image: port-of-mars/client:dev
@@ -12,13 +16,19 @@ services:
       - /code/client/node_modules
       - ./.prettierrc:/code/.prettierrc
     ports:
-      - '127.0.0.1:8081:8080'
+      - "127.0.0.1:8081:8080"
   server:
     build:
       dockerfile: server/deploy/Dockerfile.dev
+      args:
+        BASE_IMAGE: ${POM_DEV_ARCH}node:16-bullseye-slim
     ports:
-      - '127.0.0.1:2567:2567'
+      - "127.0.0.1:2567:2567"
     volumes:
       - ./server:/code/server
       - ./shared:/code/shared
       - /code/server/node_modules
+  db:
+    image: ${POM_DEV_ARCH}postgres:12
+  redis:
+    image: ${POM_DEV_ARCH}redis:7

--- a/server/deploy/Dockerfile.dev
+++ b/server/deploy/Dockerfile.dev
@@ -1,4 +1,5 @@
-FROM node:16-bullseye-slim
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 LABEL maintainer="Allen Lee <allen.lee@asu.edu>"
 


### PR DESCRIPTION
Adds dynamic docker images for x86 (default)/arm64 to negate the need for manually adjusting build files

Need to dig deeper to figure out why `arm64v8/node` doesn't work for the client base image. Also need to make sure the correct image gets pulled when actually on an arm64/apple chip host

supposed to resolve virtualcommons/planning#68