### PR TITLE
Solo game data export

### DIFF
--- a/server/src/entity/SoloGame.ts
+++ b/server/src/entity/SoloGame.ts
@@ -6,10 +6,12 @@ import {
   PrimaryGeneratedColumn,
   CreateDateColumn,
   JoinColumn,
+  OneToMany,
 } from "typeorm";
 import { SoloGameTreatment } from "./SoloGameTreatment";
 import { SoloMarsEventDeck } from "./SoloMarsEventDeck";
 import { SoloPlayer } from "./SoloPlayer";
+import { SoloGameRound } from "./SoloGameRound";
 import { SoloGameStatus } from "@port-of-mars/shared/sologame";
 
 @Entity()
@@ -33,6 +35,9 @@ export class SoloGame {
 
   @Column()
   treatmentId!: number;
+
+  @OneToMany(() => SoloGameRound, round => round.game)
+  rounds!: SoloGameRound[];
 
   @OneToOne(type => SoloMarsEventDeck, { nullable: false })
   @JoinColumn()

--- a/server/src/entity/SoloGameRound.ts
+++ b/server/src/entity/SoloGameRound.ts
@@ -6,9 +6,11 @@ import {
   CreateDateColumn,
   JoinColumn,
   OneToMany,
+  ManyToOne,
 } from "typeorm";
 import { SoloPlayerDecision } from "./SoloPlayerDecision";
 import { SoloMarsEventDeckCard } from "./SoloMarsEventDeckCard";
+import { SoloGame } from "./SoloGame";
 
 @Entity()
 export class SoloGameRound {
@@ -20,6 +22,10 @@ export class SoloGameRound {
 
   @Column()
   gameId!: number;
+
+  @ManyToOne(type => SoloGame, game => game.rounds)
+  @JoinColumn({ name: "gameId" })
+  game!: SoloGame;
 
   @Column()
   roundNumber!: number;

--- a/server/src/entity/SoloGameRound.ts
+++ b/server/src/entity/SoloGameRound.ts
@@ -33,6 +33,13 @@ export class SoloGameRound {
   @OneToMany(type => SoloMarsEventDeckCard, card => card.round)
   cards!: SoloMarsEventDeckCard[];
 
+  // these are the initial values AFTER wear and tear
+  @Column()
+  initialSystemHealth!: number;
+
+  @Column()
+  initialPoints!: number;
+
   @OneToOne(type => SoloPlayerDecision, { nullable: false })
   @JoinColumn()
   decision!: SoloPlayerDecision;

--- a/server/src/migration/1701799216158-AddGameRoundsRelationship.ts
+++ b/server/src/migration/1701799216158-AddGameRoundsRelationship.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddGameRoundsRelationship1701799216158 implements MigrationInterface {
+  name = "AddGameRoundsRelationship1701799216158";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // remove corrupted round entries (where gameId is 0)
+    await queryRunner.query(`DELETE FROM "solo_game_round" WHERE "gameId" = 0`);
+    await queryRunner.query(
+      `ALTER TABLE "solo_game_round" ADD CONSTRAINT "FK_4561cd9a73086f238bc0433e0d2" FOREIGN KEY ("gameId") REFERENCES "solo_game"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "solo_game_round" DROP CONSTRAINT "FK_4561cd9a73086f238bc0433e0d2"`
+    );
+  }
+}

--- a/server/src/migration/1701805620516-ComputeSoloRoundInitialValues.ts
+++ b/server/src/migration/1701805620516-ComputeSoloRoundInitialValues.ts
@@ -1,0 +1,104 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+import { SoloGame, SoloGameRound } from "@port-of-mars/server/entity";
+import { SoloGameState } from "@port-of-mars/server/rooms/sologame/state";
+
+const WEAR_AND_TEAR = SoloGameState.DEFAULTS.systemHealthWear;
+const MAX_SYSTEM_HEALTH = SoloGameState.DEFAULTS.systemHealthMax;
+const STARTING_POINTS = SoloGameState.DEFAULTS.points;
+
+export class ComputeSoloRoundInitialValues1701805620516 implements MigrationInterface {
+  name = "ComputeSoloRoundInitialValues1701805620516";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // add (temporarily nullable) columns to SoloGameRound
+    await queryRunner.addColumns("solo_game_round", [
+      new TableColumn({
+        name: "initialSystemHealth",
+        type: "int",
+        isNullable: true,
+      }),
+      new TableColumn({
+        name: "initialPoints",
+        type: "int",
+        isNullable: true,
+      }),
+    ]);
+
+    await this.deleteSuperfluousRounds(queryRunner);
+    await this.computeMissingInitialValues(queryRunner);
+
+    // remove nullable constraint from columns
+    await queryRunner.changeColumn(
+      "solo_game_round",
+      "initialSystemHealth",
+      new TableColumn({
+        name: "initialSystemHealth",
+        type: "int",
+        isNullable: false,
+      })
+    );
+    await queryRunner.changeColumn(
+      "solo_game_round",
+      "initialPoints",
+      new TableColumn({
+        name: "initialPoints",
+        type: "int",
+        isNullable: false,
+      })
+    );
+  }
+
+  private async computeMissingInitialValues(queryRunner: QueryRunner): Promise<void> {
+    // fetch all existing games with rounds, cards, decisions
+    const games = await queryRunner.manager.find(SoloGame, {
+      relations: ["rounds", "rounds.cards", "rounds.decision"],
+    });
+    for (const game of games) {
+      let initialSystemHealth = MAX_SYSTEM_HEALTH;
+      let initialPoints = STARTING_POINTS;
+      game.rounds.sort((a, b) => a.roundNumber - b.roundNumber);
+      for (const round of game.rounds) {
+        // simulate a round
+        // apply wear/tear -> save initial values -> apply cards -> apply decision -> repeat
+        initialSystemHealth = Math.max(0, initialSystemHealth - WEAR_AND_TEAR);
+        await queryRunner.manager.update(SoloGameRound, round.id, {
+          initialSystemHealth,
+          initialPoints,
+        });
+        for (const card of round.cards) {
+          initialSystemHealth = Math.min(
+            MAX_SYSTEM_HEALTH,
+            initialSystemHealth + card.systemHealthEffect
+          );
+          initialPoints = Math.max(0, initialPoints + card.pointsEffect);
+        }
+        if (round.decision) {
+          initialSystemHealth = Math.min(
+            MAX_SYSTEM_HEALTH,
+            initialSystemHealth + round.decision.systemHealthInvestment
+          );
+          initialPoints = Math.max(0, initialPoints + round.decision.pointsInvestment);
+        }
+      }
+    }
+  }
+
+  private async deleteSuperfluousRounds(queryRunner: QueryRunner): Promise<void> {
+    // remove duplicate round records that were created by a bug in the game logic
+    // we keep the last created round since this is the one that is referenced by the
+    // deck cards
+    await queryRunner.query(`
+        DELETE FROM "solo_game_round"
+        WHERE "id" NOT IN (
+            SELECT MAX("id")
+            FROM "solo_game_round"
+            GROUP BY "gameId", "roundNumber"
+        )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "solo_game_round" DROP COLUMN "initialPoints"`);
+    await queryRunner.query(`ALTER TABLE "solo_game_round" DROP COLUMN "initialSystemHealth"`);
+  }
+}

--- a/server/src/rooms/sologame/commands.ts
+++ b/server/src/rooms/sologame/commands.ts
@@ -88,6 +88,7 @@ export class SetFirstRoundCmd extends CmdWithoutPayload {
     this.state.systemHealth = defaults.systemHealthMax - defaults.systemHealthWear;
     this.state.timeRemaining = defaults.timeRemaining;
     this.state.player.resources = defaults.resources;
+    this.state.updateRoundInitialValues();
     this.state.isRoundTransitioning = false;
 
     return [new SendHiddenParamsCmd()];
@@ -278,6 +279,7 @@ export class SetNextRoundCmd extends CmdWithoutPayload {
 
     this.state.round += 1;
     this.state.systemHealth = Math.max(0, this.state.systemHealth - defaults.systemHealthWear);
+    this.state.updateRoundInitialValues();
 
     if (this.state.systemHealth <= 0) {
       return new EndGameCmd().setPayload({ status: "defeat" });

--- a/server/src/rooms/sologame/commands.ts
+++ b/server/src/rooms/sologame/commands.ts
@@ -118,7 +118,11 @@ export class SendHiddenParamsCmd extends CmdWithoutPayload {
 }
 export class ApplyCardCmd extends Cmd<{ playerSkipped: boolean }> {
   validate() {
-    return this.state.activeCardId >= 0 && this.state.status === "incomplete";
+    return (
+      this.state.activeCardId >= 0 &&
+      this.state.status === "incomplete" &&
+      this.state.systemHealth > 0
+    );
   }
 
   async execute({ playerSkipped } = this.payload) {

--- a/server/src/rooms/sologame/state.ts
+++ b/server/src/rooms/sologame/state.ts
@@ -72,6 +72,8 @@ export class SoloGameState extends Schema {
   @type("boolean") isRoundTransitioning = false;
 
   gameId = 0;
+  roundInitialSystemHealth = SoloGameState.DEFAULTS.systemHealthMax;
+  roundInitialPoints = 0;
   // hidden properties
   maxRound = SoloGameState.DEFAULTS.maxRound.max;
   twoEventsThreshold = SoloGameState.DEFAULTS.twoEventsThreshold.max;
@@ -104,6 +106,11 @@ export class SoloGameState extends Schema {
 
   get nextRoundCard() {
     return this.roundEventCards.find(card => !card.expired);
+  }
+
+  updateRoundInitialValues() {
+    this.roundInitialSystemHealth = this.systemHealth;
+    this.roundInitialPoints = this.points;
   }
 
   updateVisibleCards() {


### PR DESCRIPTION
PR to triple-check since this involves some complicated data migration

exporting is relatively straightforward but there were 2 problems:

- bug causing redundant solo_game_round records
- need for additional game state data (initial points and initial system health for each round) that we ideally wouldn't rely on inferring with a fragile routine in the future