### PR TITLE
feat: track + notify user signups

### DIFF
--- a/server/src/entity/TournamentRoundDate.ts
+++ b/server/src/entity/TournamentRoundDate.ts
@@ -1,5 +1,14 @@
-import { Column, Entity, ManyToOne, CreateDateColumn, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Column,
+  Entity,
+  JoinTable,
+  ManyToMany,
+  ManyToOne,
+  CreateDateColumn,
+  PrimaryGeneratedColumn,
+} from "typeorm";
 import { TournamentRound } from "./TournamentRound";
+import { TournamentRoundInvite } from "./TournamentRoundInvite";
 
 @Entity()
 export class TournamentRoundDate {
@@ -11,6 +20,10 @@ export class TournamentRoundDate {
 
   @ManyToOne(type => TournamentRound, tournamentRound => tournamentRound.scheduledDates)
   tournamentRound!: TournamentRound;
+
+  @ManyToMany(type => TournamentRoundInvite)
+  @JoinTable()
+  signups!: TournamentRoundInvite[];
 
   @CreateDateColumn()
   dateCreated!: Date;

--- a/server/src/entity/TournamentRoundInvite.ts
+++ b/server/src/entity/TournamentRoundInvite.ts
@@ -1,6 +1,7 @@
 import {
   Column,
   Entity,
+  ManyToMany,
   ManyToOne,
   CreateDateColumn,
   PrimaryGeneratedColumn,
@@ -8,6 +9,7 @@ import {
 } from "typeorm";
 import { TournamentRound } from "./TournamentRound";
 import { User } from "./User";
+import { TournamentRoundDate } from "./TournamentRoundDate";
 
 @Entity()
 @Unique(["user", "tournamentRound"])
@@ -20,6 +22,9 @@ export class TournamentRoundInvite {
 
   @ManyToOne(type => TournamentRound, tournamentRound => tournamentRound.invitations)
   tournamentRound!: TournamentRound;
+
+  @ManyToMany(type => TournamentRoundDate, tournamentRoundDate => tournamentRoundDate.signups)
+  signupDates!: TournamentRoundDate[];
 
   @Column()
   userId!: number;

--- a/server/src/migration/1702416761748-AddTournamentRoundSignupDates.ts
+++ b/server/src/migration/1702416761748-AddTournamentRoundSignupDates.ts
@@ -1,0 +1,22 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddTournamentRoundSignupDates1702416761748 implements MigrationInterface {
+    name = 'AddTournamentRoundSignupDates1702416761748'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "tournament_round_date_signups_tournament_round_invite" ("tournamentRoundDateId" integer NOT NULL, "tournamentRoundInviteId" integer NOT NULL, CONSTRAINT "PK_ea476e541957d189cb43e5566fb" PRIMARY KEY ("tournamentRoundDateId", "tournamentRoundInviteId"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_179d52130a0f8722d72cfff0c5" ON "tournament_round_date_signups_tournament_round_invite" ("tournamentRoundDateId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_d78ddb4862cff6e11870e81ced" ON "tournament_round_date_signups_tournament_round_invite" ("tournamentRoundInviteId") `);
+        await queryRunner.query(`ALTER TABLE "tournament_round_date_signups_tournament_round_invite" ADD CONSTRAINT "FK_179d52130a0f8722d72cfff0c5d" FOREIGN KEY ("tournamentRoundDateId") REFERENCES "tournament_round_date"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "tournament_round_date_signups_tournament_round_invite" ADD CONSTRAINT "FK_d78ddb4862cff6e11870e81ced8" FOREIGN KEY ("tournamentRoundInviteId") REFERENCES "tournament_round_invite"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "tournament_round_date_signups_tournament_round_invite" DROP CONSTRAINT "FK_d78ddb4862cff6e11870e81ced8"`);
+        await queryRunner.query(`ALTER TABLE "tournament_round_date_signups_tournament_round_invite" DROP CONSTRAINT "FK_179d52130a0f8722d72cfff0c5d"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_d78ddb4862cff6e11870e81ced"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_179d52130a0f8722d72cfff0c5"`);
+        await queryRunner.query(`DROP TABLE "tournament_round_date_signups_tournament_round_invite"`);
+    }
+
+}


### PR DESCRIPTION
Enable participants to sign up for specific launch time(s) while viewing the launch schedule in their tournament / player dashboard.

1. N minutes before a scheduled launch time, send an email reminder to anyone who hasn't 1/ filled out the intro survey 2/ already entered the lobby 3/ participated in a previous game
2. provide a visual indicator of number of total signups in that time slot

Next steps:

1. create toggle button UI to "signup" or "un-signup" for a specific TournamentRoundDate
2. build backend endpoints to do the data things on the backend to signup / unsignup
3. build backend schedule logic to send an email reminder to eligible signed up participants when the lobby opens (and a few minutes before the lobby closes?)

refs https://github.com/virtualcommons/planning/issues/63